### PR TITLE
using perceptual difference from a control image for tests instead of a data buffer hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,15 @@
     "libheif-js": "^1.6.1"
   },
   "devDependencies": {
+    "buffer-to-uint8array": "^1.1.0",
     "chai": "^4.2.0",
     "eslint": "^5.16.0",
     "fs-extra": "^8.1.0",
     "jimp": "^0.9.3",
     "mocha": "^7.0.0",
     "node-fetch": "^2.6.0",
+    "pixelmatch": "^5.2.1",
+    "pngjs": "^5.0.0",
     "rootrequire": "^1.0.0"
   },
   "engines": {

--- a/scripts/images.js
+++ b/scripts/images.js
@@ -14,8 +14,17 @@ const images = [{
   name: '0002.heic', // single image
   url: drive('1J_761fe_HWSijAthq7h_D2Zsf1_es1cT')
 }, {
+  name: '0002-control.png', // single image control
+  url: drive('1uomSNTAK5FifvI72lYi6T42zhvVv1LwH')
+}, {
   name: '0003.heic', // multiple images
   url: drive('1Iru2g084yZGz-eRagiqZgccRJZfGLYgS')
+}, {
+  name: '0003-0-control.png', // multiple images control, index 0
+  url: drive('1FZ9mJVj54MpD4c5TMfiOrarzkrT3pr2U')
+}, {
+  name: '0003-1-control.png', // multiple images control, index 1, 2
+  url: drive('1qD4-V6FcU2ffpNm0ZxKO2cpqbol73tok')
 }].map(img => {
   img.path = resolve(img.name);
   return img;
@@ -27,7 +36,7 @@ const images = [{
     const res = await fetch(url);
 
     if (!res.ok) {
-      throw new Error(`failed to download ${name} at ${url}`);
+      throw new Error(`failed to download ${name} at ${url}: ${res.status} ${res.statusText}`);
     }
 
     const buffer = await res.buffer();


### PR DESCRIPTION
This allows slight differences in image rendering due to libheif updates to pass when testing. These differences are expected with libheif improvements.