### PR TITLE
[BREAKING] image is generated as a Uint8ClampedArray instead of an ArrayBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ const decode = require('heic-decode');
   const {
     width,  // integer width of the image
     height, // integer height of the image
-    data    // ArrayBuffer containing decoded raw image data
+    data    // Uint8ClampedArray containing pixel data
   } = await decode({ buffer });
 })();
 ```
@@ -54,13 +54,13 @@ const decode = require('heic-decode');
     const {
       width,  // integer width of the image
       height, // integer height of the image
-      data    // ArrayBuffer containing decoded raw image data
+      data    // Uint8ClampedArray containing pixel data
     } = await image.decode();
   }
 })();
 ```
 
-You can use this data to integrate with other imaging libraries for processing.
+When the images are decoded, the return value is a plain object in the format of [`ImageData`](https://developer.mozilla.org/en-US/docs/Web/API/ImageData). You can use this object to integrate with other imaging libraries for processing.
 
 _Note that while the decoder returns a Promise, it does the majority of the work synchronously, so you should consider using a worker thread in order to not block the main thread in highly concurrent production environments._
 

--- a/lib.js
+++ b/lib.js
@@ -27,18 +27,17 @@ const decodeImage = async (image) => {
   const width = image.get_width();
   const height = image.get_height();
 
-  const arrayBuffer = await new Promise((resolve, reject) => {
+  const { data } = await new Promise((resolve, reject) => {
     image.display({ data: new Uint8ClampedArray(width*height*4), width, height }, (displayData) => {
       if (!displayData) {
         return reject(new Error('HEIF processing error'));
       }
 
-      // get the ArrayBuffer from the Uint8Array
-      resolve(displayData.data.buffer);
+      resolve(displayData);
     });
   });
 
-  return { width, height, data: arrayBuffer };
+  return { width, height, data };
 };
 
 module.exports = libheif => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -53,7 +53,7 @@ function runTests(decode) {
 
     expect(width).to.equal(control.width);
     expect(height).to.equal(control.height);
-    expect(data).to.be.instanceof(ArrayBuffer);
+    expect(data).to.be.instanceof(Uint8ClampedArray);
 
     compare(control.data, data, control.width, control.height);
   });
@@ -82,6 +82,7 @@ function runTests(decode) {
 
       expect(image).to.have.property('width', control.width);
       expect(image).to.have.property('height', control.height);
+      expect(image).to.have.property('data').and.to.be.instanceOf(Uint8ClampedArray);
 
       compare(control.data, image.data, control.width, control.height, `actual image at index ${i} did not match control`);
     }


### PR DESCRIPTION
This matches the standard [`ImageData`](https://developer.mozilla.org/en-US/docs/Web/API/ImageData) object, which is more useful for interoperability.