### PR TITLE
Update libheif-js minimum version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/catdad-experiments/heic-decode#readme",
   "dependencies": {
-    "libheif-js": "^1.17.1"
+    "libheif-js": "^1.18.0"
   },
   "devDependencies": {
     "buffer-to-uint8array": "^1.1.0",


### PR DESCRIPTION
Noticed that certain (possibly newer heic images) were no longer being properly decoded this month. However, heic-app was working just fine with my test image, and I noticed it's using the latest version of libheif-js. Bumping up the version fixed the issue on my end.